### PR TITLE
Looping

### DIFF
--- a/RSMods/MemHelpers.cpp
+++ b/RSMods/MemHelpers.cpp
@@ -526,7 +526,7 @@ bool MemHelpers::IsInStringArray(std::string stringToCheckIfInsideArray, std::ve
 /// <param name="bottomRightY"> - BOTTOM right of textbox</param>
 /// <param name="pDevice"> - Device Pointer</param>
 /// <param name="setFontSize"> - Override font size</param>
-void MemHelpers::DX9DrawText(std::string textToDraw, int textColorHex, int topLeftX, int topLeftY, int bottomRightX, int bottomRightY, LPDIRECT3DDEVICE9 pDevice, Resolution setFontSize)
+void MemHelpers::DX9DrawText(std::string textToDraw, int textColorHex, int topLeftX, int topLeftY, int bottomRightX, int bottomRightY, LPDIRECT3DDEVICE9 pDevice, Resolution setFontSize, DWORD format)
 {
 	Resolution WindowSize = MemHelpers::GetWindowSize();
 
@@ -548,7 +548,7 @@ void MemHelpers::DX9DrawText(std::string textToDraw, int textColorHex, int topLe
 
 	// Preload And Draw The Text (Supposed to reduce the performance hit (It's D3D/DX9 but still good practice))
 	DX9FontEncapsulation->PreloadTextA(textToDraw.c_str(), textToDraw.length());
-	DX9FontEncapsulation->DrawTextA(NULL, textToDraw.c_str(), -1, &TextRectangle, DT_LEFT | DT_NOCLIP, textColorHex);
+	DX9FontEncapsulation->DrawTextA(NULL, textToDraw.c_str(), -1, &TextRectangle, format, textColorHex);
 
 	// Let's clean up our junk, since fonts don't do it automatically.
 	if (DX9FontEncapsulation) {

--- a/RSMods/MemHelpers.hpp
+++ b/RSMods/MemHelpers.hpp
@@ -30,7 +30,7 @@ namespace MemHelpers {
 	int GetTrueTuning();
 	Resolution GetWindowSize();
 	bool IsInStringArray(std::string stringToCheckIfInsideArray, std::vector<std::string> stringVector = std::vector<std::string>());
-	void DX9DrawText(std::string textToDraw, int textColorHex, int topLeftX, int topLeftY, int bottomRightX, int bottomRightY, LPDIRECT3DDEVICE9 pDevice, Resolution setFontSize = { NULL, NULL });
+	void DX9DrawText(std::string textToDraw, int textColorHex, int topLeftX, int topLeftY, int bottomRightX, int bottomRightY, LPDIRECT3DDEVICE9 pDevice, Resolution setFontSize = { NULL, NULL }, DWORD format = DT_LEFT | DT_NOCLIP);
 	void ToggleDrunkMode(bool enable);
 	bool IsInSong();
 	Tuning GetTuningAtTuner();

--- a/RSMods/dllmain.cpp
+++ b/RSMods/dllmain.cpp
@@ -255,33 +255,6 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM keyPressed, LPARAM lParam) {
 			//	std::cout << "Restart Complete!" << std::endl;
 			//}
 
-
-			else if (keyPressed == Settings::GetKeyBind("RRSpeedKey") && Settings::ReturnSettingValue("RRSpeedAboveOneHundred") == "on" && (MemHelpers::IsInStringArray(D3DHooks::currentMenu, fastRRModes)) && RiffRepeater::loggedCurrentSongID) { // Riff Repeater over 100%
-
-				// Convert UI Speed -> Real Speed
-				realSongSpeed = RiffRepeater::GetSpeed(true);
-
-				// Add / Subtract User's Interval
-
-				if (GetAsyncKeyState(VK_SHIFT) < 0)
-					realSongSpeed -= (float)Settings::GetModSetting("RRSpeedInterval");
-				else
-					realSongSpeed += (float)Settings::GetModSetting("RRSpeedInterval");
-
-				// Set Limits
-				if (realSongSpeed > 400.f) // Cap at 400. Plugin only goes down to 25. 10000 / 25 = 400.
-					realSongSpeed = 400.f;
-
-				if (realSongSpeed < 25.f) // Cap at 25. Plugin only goes up to 400. 10000 / 400 = 25.
-					realSongSpeed = 25.f;
-
-				// Save new speed, and save it to a file (for streamers to use as an on-screen overlay)
-				RiffRepeater::SetSpeed(realSongSpeed, true);
-				RiffRepeater::EnableTimeStretch();
-				saveNewRRSpeedToFile = true;
-
-				std::cout << "Triggered Mod: Riff Repeater Speed set to " << realSongSpeed << "% which is equivalent to " << RiffRepeater::ConvertSpeed(realSongSpeed) << " Wwise RTPC." << std::endl;
-			}
 			else if (keyPressed == Settings::GetKeyBind("ToggleExtendedRangeKey"))
 			{
 				Settings::ToggleExtendedRangeMode();
@@ -316,7 +289,38 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM keyPressed, LPARAM lParam) {
 		if (debug) {
 			if (keyPressed == VK_INSERT) // Debug menu | ImGUI
 				D3DHooks::menuEnabled = !D3DHooks::menuEnabled;
+		}
+	}
 
+	// Repeatedly trigger mod on key hold
+	else if (msg == WM_KEYDOWN) {
+		if (D3DHooks::GameLoaded) { // Game must not be on the startup videos or it will crash
+			if (keyPressed == Settings::GetKeyBind("RRSpeedKey") && Settings::ReturnSettingValue("RRSpeedAboveOneHundred") == "on" && (MemHelpers::IsInStringArray(D3DHooks::currentMenu, fastRRModes)) && RiffRepeater::loggedCurrentSongID) { // Riff Repeater over 100%
+
+				// Convert UI Speed -> Real Speed
+				realSongSpeed = RiffRepeater::GetSpeed(true);
+
+				// Add / Subtract User's Interval
+
+				if (GetAsyncKeyState(VK_SHIFT) < 0)
+					realSongSpeed -= (float)Settings::GetModSetting("RRSpeedInterval");
+				else
+					realSongSpeed += (float)Settings::GetModSetting("RRSpeedInterval");
+
+				// Set Limits
+				if (realSongSpeed > 400.f) // Cap at 400. Plugin only goes down to 25. 10000 / 25 = 400.
+					realSongSpeed = 400.f;
+
+				if (realSongSpeed < 25.f) // Cap at 25. Plugin only goes up to 400. 10000 / 400 = 25.
+					realSongSpeed = 25.f;
+
+				// Save new speed, and save it to a file (for streamers to use as an on-screen overlay)
+				RiffRepeater::SetSpeed(realSongSpeed, true);
+				RiffRepeater::EnableTimeStretch();
+				saveNewRRSpeedToFile = true;
+
+				std::cout << "Triggered Mod: Song Speed set to " << realSongSpeed << "% which is equivalent to " << RiffRepeater::ConvertSpeed(realSongSpeed) << " Wwise RTPC." << std::endl;
+			}
 		}
 	}
 


### PR DESCRIPTION
Updates to the looping mod to make it feel more polished

1. Cleaned up some of the logic.
2. Made it so resuming after a pause starts you shortly before the loop (gives the player some time to prepare and makes the whole mod just feel more official/polished).
3. Cleaned up some of the text positioning (text is positioned more precisely now and centered properly).
4. Changed "Riff Repeater Speed" to just say "Song Speed" since it is still active outside of the riff repeater.
5. Allow song speed to be updated repeatedly on key hold.