### PR TITLE
fix: correct 'occured' to 'occurred' typo in user-facing error message

### DIFF
--- a/GUI/UI.cs
+++ b/GUI/UI.cs
@@ -4296,7 +4296,7 @@ namespace RSMods
                         MessageBox.Show("Don't forget to hit \"Repack Audio Psarc\" when you're done.");
                     }
                     else
-                        MessageBox.Show("An error occured when converting your file.\nPlease contact the RSMods devs.");
+                        MessageBox.Show("An error occurred when converting your file.\nPlease contact the RSMods devs.");
 
                 }
             }


### PR DESCRIPTION
## Summary
Corrects a typo in the user-facing error MessageBox shown when MP3 to WAV audio conversion fails in the GUI.

## Change
- File: `GUI/UI.cs` (line ~4299)
- Fix: `occured` → `occurred`
- Before: `MessageBox.Show("An error occured when converting your file.\nPlease contact the RSMods devs.")`
- After: `MessageBox.Show("An error occurred when converting your file.\nPlease contact the RSMods devs.")`

## Testing
- Minimal one-line change in user-facing text
- No logic change, no test required
- Single commit