### PR TITLE
Validate the address FindDMAAddy returns when safe is set

### DIFF
--- a/DLL/MemUtil.cpp
+++ b/DLL/MemUtil.cpp
@@ -230,6 +230,12 @@ uintptr_t MemUtil::FindDMAAddy(uintptr_t ptr, const std::vector<unsigned int>& o
 
 		addr += offset;
 	}
+
+	// The loop validates each address before stepping through it, which leaves the
+	// final address, the one the caller actually dereferences, unchecked.
+	if (safe && IsBadReadPtr((void*)addr))
+		return 0;
+
 	return addr;
 }
 


### PR DESCRIPTION
## The bug

`DLL/MemUtil.cpp`, in `FindDMAAddy`:

```cpp
for (const auto& offset : offsets)
{
    if (safe && IsBadReadPtr((void*)addr))
        return 0;
    if (!addr) return 0;
    addr = *(uintptr_t*)addr;
    if (!addr) return 0;
    addr += offset;
}
return addr;   // never validated
```

The guard runs at the top of each iteration, so it checks every address the loop
steps through, but not the one it returns. The final `addr += offset` is applied
after the last check. With `safe` set, every intermediate hop is validated and
the address the caller actually dereferences is not.

## Where it shows

`DLL/SongTimer.cpp` is the case that led me here. The rare timer pointer is
requested with `safe` set; the base pointer above it is not:

```cpp
uintptr_t addrTimerBase = MemUtil::FindDMAAddy(Offsets::baseHandle + Offsets::ptr_timer, Offsets::ptr_timerBaseOffsets);
uintptr_t addrTimerRare = MemUtil::FindDMAAddy(Offsets::baseHandle + Offsets::ptr_timerRare, Offsets::ptr_timerRareOffsets, true);
```

The flag is there for that pointer, and the bug means it covers every hop except
the one that gets dereferenced. An address that is non-null but not readable
passes the `if (!addrTimerRare)` guard on line 18 and faults on line 26.

The window is narrow. Line 26 short-circuits, so the rare pointer is only read
when `IsInSongModes()` is true and the base timer reads `0.f`, which is the
Desolate Motion / RS2012 theme case described in the comment above it. That is
probably why this has gone unnoticed.

The existing `Invalid Pointer: (RARE) ShowSongTimer` log is the same instability
caught one hop earlier. Whether it surfaces as a logged error or an access
violation depends only on which hop fails.

## The fix

```cpp
    addr += offset;
}

if (safe && IsBadReadPtr((void*)addr))
    return 0;

return addr;
```

## Risk

None to the contract. Callers already handle a `0` return, and `SongTimer` logs
and falls back to the base timer. This turns a potential crash into the error
path that already exists.