### PR TITLE
Remove the redundant settings reload in EnumerationThread

### DIFF
--- a/DLL/dllmain.cpp
+++ b/DLL/dllmain.cpp
@@ -25,9 +25,6 @@ unsigned WINAPI EnumerationThread() {
 	while (!GameState::GameLoaded)
 		Sleep(5000);
 
-	Settings::ReadKeyBinds();
-	Settings::ReadModSettings();
-
 	int oldDLCCount = Enumeration::GetCurrentDLCCount();
 	int newDLCCount = oldDLCCount;
 


### PR DESCRIPTION
## What it does

`EnumerationThread` waits for `GameState::GameLoaded`, then calls:

```cpp
Settings::ReadKeyBinds();
Settings::ReadModSettings();
```

`ReadKeyBinds` assigns `Settings::modSettings` from an initializer list.
`ReadModSettings` assigns `modSettings` and `customSettings`. Nothing
synchronises any of it.

## Why the reload is redundant

`MainThread` already loads settings during startup:

```cpp
Settings::Initialize();
UpdateSettings();      // ReadKeyBinds + ReadModSettings + ReadStringColors
ERMode::Initialize();
GUI();                 // hooks WndProc and D3D
```

That completes before `GUI()` installs the hooks, so no window or render-thread
readers exist yet. The `EnumerationThread` call repeats part of it, omitting at
least `ReadStringColors()`, so as a reload it is also incomplete.

By the time `GameLoaded` is set, several threads are reading `modSettings`:

- `WndProc` calls `Settings::ReturnSettingValue("PreventMidSongPause")` on every
  message
- `Hook_EndScene` reaches the same call each frame via `UpdateGameWindowStacking`
- `MainThread` reads settings many times per pass in `HandlePostGameLoadedMods`

Reassigning the map while those run frees the `std::string` values they are
copying.

## The crash

Four crashes across four builds, all `FaultingOffset 0x0002b6b3` in Event Viewer.

A minidump from the game's crash handler, symbolised against the matching build:

```
Unhandled exception at 0x5B51B6B3 (xinput1_3.dll):
0xC0000005: Access violation reading location 0xDDDDDDE1.

xinput1_3.dll!std::_Container_base12::_Orphan_all() Line 1400
xinput1_3.dll!std::string::_Tidy_deallocate() Line 3082
xinput1_3.dll!std::string::{dtor}() Line 1383
xinput1_3.dll!std::_Tree_val<...pair<const string, string>>::_Erase_tree(...)
xinput1_3.dll!std::_Tree<...>::clear() Line 1374
xinput1_3.dll!std::map<string, string, less<void>>::operator=(initializer_list<...>) Line 340
xinput1_3.dll!Settings::ReadKeyBinds() Line 183
xinput1_3.dll!EnumerationThread() Line 29
xinput1_3.dll!thread_start<...>(void *) Line 97
```

`0xDD` is the debug CRT's freed-block fill. `ReadKeyBinds` assigns `modSettings`
from an initializer list, which clears the old tree, which destroys a
`std::string` whose buffer another thread had already freed.

All four crashes landed on main menu load after profile load, which is when
`GameState::GameLoaded` flips and this reload runs.

(Line numbers come from a fork of 1.2.8.2 with an unrelated feature added, so they
will not line up exactly with this branch.)

## Scope

This removes the reload that runs automatically on every launch. Settings rebuilds
triggered by Ctrl+A in `HandleKeyUp` and by `WM_COPYDATA "update all"` still run on
the WndProc thread while other threads read, so this is not a complete fix for
concurrent access. It removes the unsolicited case, which is the one users hit
without doing anything.

## Risk

Settings edited in the GUI while the game is still booting were picked up by this
reload. Once the game is running, `WM_COPYDATA` handles that properly and more
completely. That narrow boot window is the only behaviour lost.